### PR TITLE
Another attempt at fixing the build hook

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,10 @@ func check(err error) {
 
 func main() {
 
+	// Must read exe before the executable is replaced
+	exe, err := os.Readlink("/proc/self/exe")
+	check(err)
+
 	go func() {
 		http.HandleFunc("/hook", handleHook)
 		log.Println("Listening on:", *address)
@@ -52,9 +56,6 @@ func main() {
 	signal.Stop(sig)
 
 	log.Print("HUPPING!")
-
-	exe, err := os.Readlink("/proc/self/exe")
-	check(err)
 
 	err = syscall.Exec(exe, os.Args, os.Environ())
 	check(err)

--- a/tang.hook
+++ b/tang.hook
@@ -10,7 +10,10 @@ ln -s $PWD gopath/src/tang
 echo "Installing..."
 GOPATH=$PWD/gopath go install tang
 
-cp $PWD/gopath/bin/tang ${GOPATH-~/.local}/bin
+// Must delete old binary before replacing it
+ORIGBIN=${GOPATH-~/.local}/bin
+mv $ORIGBIN $ORIGBIN.old
+cp $PWD/gopath/bin/tang $ORIGBIN
 
 echo "Sending HUP"
 pkill -HUP tang


### PR DESCRIPTION
It turns out we can't `cp` over an existing file. However, we can `mv` it or
`rm` it. If we do that, `/proc/self/exe` will be pointing to the wrong place
or gets `(deleted)` put into the symlink target.

Therefore, we need to `readlink()` before it changes to know what to exec.
