### PR TITLE
Pass ref to tang.hook

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,8 +254,10 @@ func gitCheckout(git_dir, checkout_dir, ref string) (err error) {
 	return
 }
 
-func runTang(path string) (err error) {
-	return Command(path, "./tang.hook").Run()
+func runTang(path, ref string) (err error) {
+	cmd := Command(path, "./tang.hook")
+	cmd.Env = append(os.Environ(), "TANG_REF="+ref)
+	return cmd.Run()
 }
 
 func eventPush(event PushEvent) (err error) {
@@ -299,7 +301,7 @@ func eventPush(event PushEvent) (err error) {
 		return
 	}
 
-	err = runTang(path.Join(git_dir, checkout_dir))
+	err = runTang(path.Join(git_dir, checkout_dir), event.Ref)
 	if err != nil {
 		return
 	}

--- a/tang.hook
+++ b/tang.hook
@@ -2,13 +2,13 @@
 
 set -e
 
+echo "# tang.hook invoked at ${TANG_REF}"
+
 if ! go test -v;
 then
 	echo "Tests failed"
 	exit 1
 fi
-
-echo "Would have built tang"
 
 mkdir -p gopath/src
 ln -s $PWD gopath/src/tang


### PR DESCRIPTION
This is so that the tang.hook can tell which branch is being used

(and deploy if it feels like it)
