### PR TITLE
Drop privileges so we can listen on :80 without being root

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@ func init() {
 }
 
 func TestPush(t *testing.T) {
-
 	e := PushEvent{
 		Ref: "refs/heads/master",
 		Repository: Repository{
@@ -25,8 +24,10 @@ func TestPush(t *testing.T) {
 		Pusher:    Pusher{Name: "testuser"},
 		NonGithub: NonGithub{NoBuild: true},
 	}
+
 	allowedPushersSet["testuser"] = true
 	defer delete(allowedPushersSet, "testuser")
+
 	err := eventPush(e)
 	if err != nil {
 		t.Error(err)
@@ -36,6 +37,7 @@ func TestPush(t *testing.T) {
 func TestEvent(t *testing.T) {
 	allowedPushersSet["testuser"] = true
 	defer delete(allowedPushersSet, "testuser")
+
 	err := handleEvent("push", []byte(`{
 		"ref": "refs/heads/master",
 		"repository": {"name": "tang", "organization": "example", "url": "."},


### PR DESCRIPTION
This was much harder than I expected because of the need to pass
a the ("privileged") file descriptor to the child when we reload :(.

That was hard because it turns out that go's garbage collector closes
file descriptors on our behalf if we aren't careful.
