### PR TITLE
Fix a bug where ^C would exit rather than restart

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 	signal.Stop(sig)
 
 	// We've been instructed to exit.
-	log.Printf("Recieved %v, revision %v restarting...", value, tangRev[:4])
+	log.Printf("Received %v, revision %v restarting...", value, (tangRev + "doge")[:4])
 
 	// TODO(pwaller) Don't exec before everything else has finished.
 	// OTOH, that means waiting for other cruft in the pipeline, which


### PR DESCRIPTION
when the tangRev was not set.
